### PR TITLE
Invalid bytes support

### DIFF
--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -26,7 +26,22 @@ def _str_find_all(a_str, sub):
 
 
 class ChainBuilder(object):
+    """
+    This class provides functions to generate common ropchains based on existing gadgets.
+    """
+
     def __init__(self, project, gadgets, duplicates, reg_list, base_pointer, badbytes, roparg_filler):
+        """
+        Initializes the chain builder.
+
+        :param project: Angr project
+        :param gadgets: a list of RopGadget gadgets
+        :param duplicates:
+        :param reg_list: A list of multipurpose registers
+        :param base_pointer: The name ("offset") for base pointer register
+        :param badbytes: A list with badbytes, which we should avaoid
+        :param roparg_filler: An integer used when popping superfluous registers
+        """
         self.project = project
         self._gadgets = gadgets
         # TODO get duplicates differently?
@@ -56,7 +71,6 @@ class ChainBuilder(object):
 
         # filtered gadget cache
         self._filtered_reg_gadgets = None
-
 
     def set_regs(self, modifiable_memory_range=None, use_partial_controllers=False, rebase_regs=None, **registers):
         """

--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -43,7 +43,6 @@ class ChainBuilder(object):
             self._syscall_instructions = {"\xcd\x80"}
 
         self._execve_syscall = None
-        # TODO this code is replicated in a couple of places...
         if self.project.loader.main_bin.os == "unix":
             if self.project.arch.bits == 64:
                 self._execve_syscall = 59
@@ -57,6 +56,7 @@ class ChainBuilder(object):
 
         # filtered gadget cache
         self._filtered_reg_gadgets = None
+
 
     def set_regs(self, modifiable_memory_range=None, use_partial_controllers=False, rebase_regs=None, **registers):
         """
@@ -72,6 +72,7 @@ class ChainBuilder(object):
 
         if rebase_regs is None:
             rebase_regs = set()
+
         gadgets, best_stack_change, _ = self._find_reg_setting_gadgets(modifiable_memory_range,
                                                                        use_partial_controllers, **registers)
         if gadgets is None:

--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -3,6 +3,7 @@ import struct
 import simuvex
 
 import rop_utils
+import common
 
 from errors import RopException
 from rop_chain import RopChain
@@ -13,16 +14,6 @@ import logging
 from collections import defaultdict
 
 l = logging.getLogger("angrop.chain_builder")
-
-
-def _str_find_all(a_str, sub):
-    start = 0
-    while True:
-        start = a_str.find(sub, start)
-        if start == -1:
-            return
-        yield start
-        start += 1
 
 
 class ChainBuilder(object):
@@ -726,7 +717,7 @@ class ChainBuilder(object):
                 num_bytes = segment.max_addr-segment.min_addr
                 read_bytes = "".join(self.project.loader.memory.read_bytes(min_addr, num_bytes))
                 for syscall_instruction in self._syscall_instructions:
-                    for loc in _str_find_all(read_bytes, syscall_instruction):
+                    for loc in common.str_find_all(read_bytes, syscall_instruction):
                         addrs.append(loc + min_addr)
         return sorted(addrs)
 

--- a/angrop/chain_builder.py
+++ b/angrop/chain_builder.py
@@ -163,12 +163,18 @@ class ChainBuilder(object):
 
         return chain
 
-    def write_to_mem(self, addr, string_data):
+    def write_to_mem(self, addr, string_data, fill_byte="\xff"):
         """
         :param addr: address to store the string
         :param string_data: string to store
+        :param fill_byte: a byte to use to fill up the string if necessary
         :return: a rop chain
         """
+
+        if not (isinstance(fill_byte, basestring) and len(fill_byte) == 1):
+            print "fill_byte is not a one byte string, aborting"
+            return
+
         # create a dict of bytes per write to gadgets
         # assume we need intersection of addr_dependencies and data_dependencies to be 0
         # TODO could allow mem_reads as long as we control the address?
@@ -250,7 +256,7 @@ class ChainBuilder(object):
             to_write = string_data[i: i+bytes_per_write]
             # pad if needed
             if len(to_write) < bytes_per_write:
-                to_write += "\xff" * (bytes_per_write-len(to_write))
+                to_write += fill_byte * (bytes_per_write-len(to_write))
             chain = chain + self._write_to_mem_with_gadget(best_gadget, addr + i, to_write, use_partial_controllers)
 
         return chain

--- a/angrop/common.py
+++ b/angrop/common.py
@@ -1,0 +1,10 @@
+
+
+def str_find_all(a_str, sub):
+    start = 0
+    while True:
+        start = a_str.find(sub, start)
+        if start == -1:
+            return
+        yield start
+        start += 1

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -91,6 +91,8 @@ class ROP(angr.Analysis):
         self.stack_pivots = []
         self._duplicates = []
 
+        self.badbytes = []
+
         num_to_check = len(list(self._addresses_to_check()))
         # fast mode
         if fast_mode is None:
@@ -189,6 +191,17 @@ class ROP(angr.Analysis):
         cache_tuple = pickle.load(open(path, "rb"))
         self._load_cache_tuple(cache_tuple)
 
+    def set_badbytes(self, badbytes):
+        if not isinstance(badbytes, list):
+            print "Require a list: [0x00, 0x09]"
+            return
+        self.badbytes = badbytes
+        if len(self.gadgets) > 0:
+            self.chain_builder._set_badbytes(self.badbytes)
+
+    def get_badbytes(self):
+        return self.badbytes
+
     def _get_cache_tuple(self):
         return self.gadgets, self.stack_pivots, self._duplicates
 
@@ -208,7 +221,7 @@ class ROP(angr.Analysis):
             return self._chain_builder
         elif len(self.gadgets) > 0:
             self._chain_builder = chain_builder.ChainBuilder(self.project, self.gadgets, self._duplicates,
-                                                             self._reg_list, self._base_pointer)
+                                                             self._reg_list, self._base_pointer, self.badbytes)
             return self._chain_builder
         else:
             raise Exception("No gadgets, call find_gadgets() or load_gadgets() first")

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -46,6 +46,10 @@ class ROP(angr.Analysis):
     """
     This class is a semantic aware rop gadget finder
     It is a work in progress, so don't be surprised if something doesn't quite work
+
+    After calling find_gadgets(), find_gadgets_single_threaded() or load_gadgets(),
+    self.gadgets, self.stack_pivots, and self._duplicates is populated.
+    Additionally, all public methods from ChainBuilder are copied into ROP.
     """
 
     def __init__(self, only_check_near_rets=True, max_block_size=20, max_sym_mem_accesses=4, fast_mode=None):
@@ -69,6 +73,7 @@ class ROP(angr.Analysis):
         self._ip_reg = a.register_names[a.ip_offset]
         self._base_pointer = a.register_names[a.bp_offset]
 
+        # get list of multipurpose registers
         self._reg_list = a.default_symbolic_registers
         # prune the register list of the instruction pointer and the stack pointer
         self._reg_list = filter(lambda r: r != self._sp_reg, self._reg_list)
@@ -77,11 +82,12 @@ class ROP(angr.Analysis):
         # get ret locations
         self._ret_locations = self._get_ret_locations()
 
-        # list of gadgets
+        # list of RopGadget's
         self.gadgets = []
         self.stack_pivots = []
         self._duplicates = []
 
+        # RopChain settings
         self.badbytes = []
         self.roparg_filler = 0x0
 
@@ -117,6 +123,7 @@ class ROP(angr.Analysis):
         """
         Finds all the gadgets in the binary by calling analyze_gadget on every address near a ret.
         Saves gadgets in self.gadgets
+        Saves stack pivots in self.stack_pivots
         :param processes: number of processes to use
         """
         self.gadgets = []
@@ -148,8 +155,9 @@ class ROP(angr.Analysis):
 
     def find_gadgets_single_threaded(self):
         """
-        Finds all the gadgets in the binary by calling analyze_gadget on every address near a ret.
+        Finds all the gadgets in the binary by calling analyze_gadget on every address near a ret
         Saves gadgets in self.gadgets
+        Saves stack pivots in self.stack_pivots
         """
         self.gadgets = []
 
@@ -176,14 +184,26 @@ class ROP(angr.Analysis):
         self._reload_chain_funcs()
 
     def save_gadgets(self, path):
+        """
+        Saves gadgets in a file.
+        :param path: A path for a file where the gadgets are stored
+        """
         with open(path, "wb") as f:
             pickle.dump(self._get_cache_tuple(), f)
 
     def load_gadgets(self, path):
+        """
+        Loads gadgets from a file.
+        :param path: A path for a file where the gadgets are loaded
+        """
         cache_tuple = pickle.load(open(path, "rb"))
         self._load_cache_tuple(cache_tuple)
 
     def set_badbytes(self, badbytes):
+        """
+        Define badbytes which should not appear in the generated ropchain.
+        :param badbytes: a list of 8 bit integers
+        """
         if not isinstance(badbytes, list):
             print "Require a list, e.g: [0x00, 0x09]"
             return
@@ -192,6 +212,11 @@ class ROP(angr.Analysis):
             self.chain_builder._set_badbytes(self.badbytes)
 
     def set_roparg_filler(self, roparg_filler):
+        """
+        Define rop gadget filler argument. These will be used if the rop chain needs to pop
+        useless registers.
+        :param roparg_filler: A integer which is used when popping useless register.
+        """
         if not isinstance(roparg_filler, int):
             print "Require an integer, e.g: 0x41414141"
             return
@@ -201,6 +226,10 @@ class ROP(angr.Analysis):
             self.chain_builder._set_roparg_filler(self.roparg_filler)
 
     def get_badbytes(self):
+        """
+        Returns list of badbytes.
+        :returns the list of badbytes
+        """
         return self.badbytes
 
     def _get_cache_tuple(self):

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -3,6 +3,7 @@ import simuvex
 
 import chain_builder
 import gadget_analyzer
+import common
 
 import pickle
 import inspect
@@ -15,16 +16,6 @@ from .rop_gadget import RopGadget, StackPivot
 from multiprocessing import Pool
 
 l = logging.getLogger('angrop.rop')
-
-
-def _str_find_all(a_str, sub):
-    start = 0
-    while True:
-        start = a_str.find(sub, start)
-        if start == -1:
-            return
-        yield start
-        start += 1
 
 
 _global_gadget_analyzer = None
@@ -395,7 +386,7 @@ class ROP(angr.Analysis):
                     num_bytes = segment.max_addr-segment.min_addr
                     read_bytes = "".join(self.project.loader.memory.read_bytes(min_addr, num_bytes))
                     for ret_instruction in ret_instructions:
-                        for loc in _str_find_all(read_bytes, ret_instruction):
+                        for loc in common.str_find_all(read_bytes, ret_instruction):
                             addrs.append(loc + min_addr)
         except KeyError:
             l.warning("Key error with segment analysis")
@@ -408,7 +399,7 @@ class ROP(angr.Analysis):
 
                     read_bytes = state.se.any_str(state.memory.load(min_addr, num_bytes))
                     for ret_instruction in ret_instructions:
-                        for loc in _str_find_all(read_bytes, ret_instruction):
+                        for loc in common.str_find_all(read_bytes, ret_instruction):
                             addrs.append(loc + min_addr)
 
         return sorted(addrs)

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -92,6 +92,7 @@ class ROP(angr.Analysis):
         self._duplicates = []
 
         self.badbytes = []
+        self.roparg_filler = 0x0
 
         num_to_check = len(list(self._addresses_to_check()))
         # fast mode
@@ -193,11 +194,20 @@ class ROP(angr.Analysis):
 
     def set_badbytes(self, badbytes):
         if not isinstance(badbytes, list):
-            print "Require a list: [0x00, 0x09]"
+            print "Require a list, e.g: [0x00, 0x09]"
             return
         self.badbytes = badbytes
         if len(self.gadgets) > 0:
             self.chain_builder._set_badbytes(self.badbytes)
+
+    def set_roparg_filler(self, roparg_filler):
+        if not isinstance(roparg_filler, int):
+            print "Require an integer, e.g: 0x41414141"
+            return
+
+        self.roparg_filler = roparg_filler
+        if len(self.gadgets) > 0:
+            self.chain_builder._set_roparg_filler(self.roparg_filler)
 
     def get_badbytes(self):
         return self.badbytes
@@ -221,7 +231,7 @@ class ROP(angr.Analysis):
             return self._chain_builder
         elif len(self.gadgets) > 0:
             self._chain_builder = chain_builder.ChainBuilder(self.project, self.gadgets, self._duplicates,
-                                                             self._reg_list, self._base_pointer, self.badbytes)
+                                                             self._reg_list, self._base_pointer, self.badbytes, self.roparg_filler)
             return self._chain_builder
         else:
             raise Exception("No gadgets, call find_gadgets() or load_gadgets() first")

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -74,15 +74,6 @@ class ROP(angr.Analysis):
         self._reg_list = filter(lambda r: r != self._sp_reg, self._reg_list)
         self._reg_list = filter(lambda r: r != self._ip_reg, self._reg_list)
 
-        self._execve_syscall = None
-        if self.project.loader.main_bin.os == "unix":
-            if self.project.arch.bits == 64:
-                self._execve_syscall = 59
-            elif self.project.arch.bits == 32:
-                self._execve_syscall = 11
-            else:
-                raise RopException("unknown unix platform")
-
         # get ret locations
         self._ret_locations = self._get_ret_locations()
 


### PR DESCRIPTION
From the angrop pag TODO list:
> Allow setting constraints on the generated chain e.g. bytes that are valid.

The first three commits implement this requirement. 

The last three commits are small code cleanup and adding comments to the source code. 