### PR TITLE
Clarify Exception

### DIFF
--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -249,7 +249,7 @@ class ROP(angr.Analysis):
                                                              self.roparg_filler)
             return self._chain_builder
         else:
-            raise Exception("No gadgets, call find_gadgets() or load_gadgets() first")
+            raise Exception("No gadgets available, call find_gadgets() or load_gadgets() if you haven't already.")
 
     def _block_has_ip_relative(self, addr, bl):
         """

--- a/angrop/rop.py
+++ b/angrop/rop.py
@@ -97,7 +97,7 @@ class ROP(angr.Analysis):
             self._max_sym_mem_accesses = 1
             num_to_check = len(list(self._addresses_to_check()))
 
-        l.info("There are %d addresses withing %d bytes of a ret",
+        l.info("There are %d addresses within %d bytes of a ret",
                num_to_check, self._max_block_size)
 
         # gadget analyzer


### PR DESCRIPTION
Fixes a confusing situation where running `find_gadgets()` will say you forgot to run `find_gadgets()`.

```python
In [1]: rop = proj.analyses.ROP(only_check_near_rets=False, fast_mode=False, max_block_size=0x10000)
INFO    | 2017-05-02 00:41:57,037 | angrop.rop | There are 0 addresses withing 65536 bytes of a ret

In [2]: rop.find_gadgets(show_progress=False)
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
/mipswork/goon.py in <module>()
----> 1 rop.find_gadgets(show_progress=False)

/home/angr/angr-dev/angrop/angrop/rop.pyc in find_gadgets(self, processes, show_progress)
    144                 self._duplicates.append(dups)
    145         self.gadgets = sorted(self.gadgets, key=lambda x: x.addr)
--> 146         self._reload_chain_funcs()
    147
    148     def find_gadgets_single_threaded(self):

/home/angr/angr-dev/angrop/angrop/rop.pyc in _reload_chain_funcs(self)
    235
    236     def _reload_chain_funcs(self):
--> 237         for f_name, f in inspect.getmembers(self.chain_builder, predicate=inspect.ismethod):
    238             if f_name.startswith("_"):
    239                 continue

/home/angr/angr-dev/angrop/angrop/rop.pyc in chain_builder(self)
    250             return self._chain_builder
    251         else:
--> 252             raise Exception("No gadgets, call find_gadgets() or load_gadgets() first")
    253
    254     def _block_has_ip_relative(self, addr, bl):

Exception: No gadgets, call find_gadgets() or load_gadgets() first
```